### PR TITLE
fix: Conduits now save filters saved between world reloads

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitConnection.java
+++ b/src/conduits/java/com/enderio/conduits/common/blockentity/ConduitConnection.java
@@ -125,6 +125,9 @@ public class ConduitConnection implements INBTSerializable<CompoundTag> {
                 element.putInt(KEY_INSERT, dynamicState.insert().ordinal());
                 element.putInt(KEY_REDSTONE_CONTROL, dynamicState.control().ordinal());
                 element.putInt(KEY_REDSTONE_CHANNEL, dynamicState.redstoneChannel().ordinal());
+                for(SlotType slotType : SlotType.values()){
+                    element.put(slotType.name(), dynamicState.getItem(slotType).serializeNBT());
+                }
             }
             tag.put(String.valueOf(i), element);
         }
@@ -144,8 +147,9 @@ public class ConduitConnection implements INBTSerializable<CompoundTag> {
                 var insertIndex = nbt.getInt(KEY_INSERT);
                 var redControl = nbt.getInt(KEY_REDSTONE_CONTROL);
                 var redChannel = nbt.getInt(KEY_REDSTONE_CHANNEL);
-                IConnectionState prev = connectionStates[i];
-                Optional<DynamicConnectionState> dyn = Optional.ofNullable(prev instanceof DynamicConnectionState dynState ? dynState : null);
+                var filterInsert = ItemStack.of(nbt.getCompound(SlotType.FILTER_INSERT.name()));
+                var filterExtract = ItemStack.of(nbt.getCompound(SlotType.FILTER_EXTRACT.name()));
+                var upgradeExtract = ItemStack.of(nbt.getCompound(SlotType.UPGRADE_EXTRACT.name()));
                 connectionStates[i] = new DynamicConnectionState(
                     isInsert,
                      ColorControl.values()[insertIndex],
@@ -153,9 +157,9 @@ public class ConduitConnection implements INBTSerializable<CompoundTag> {
                     ColorControl.values()[extractIndex],
                     RedstoneControl.values()[redControl],
                     ColorControl.values()[redChannel],
-                    dyn.map(DynamicConnectionState::filterInsert).orElse(ItemStack.EMPTY),
-                    dyn.map(DynamicConnectionState::filterExtract).orElse(ItemStack.EMPTY),
-                    dyn.map(DynamicConnectionState::upgradeExtract).orElse(ItemStack.EMPTY)
+                    filterInsert,
+                    filterExtract,
+                    upgradeExtract
                 );
             }
         }


### PR DESCRIPTION
# Description

When ConduitBundle (which stores information about a particular conduit) gets serialized and deserialized, it didn't take into account the items stored in each of the filter/upgrade slots. This change makes it so that the items stored in those slots is written to and from NBT.

Tested on item conduits with filter, on both insert and extract slots. No upgrade slot or fluid filters/filter slots available to test on yet.

Closes #(1)