### PR TITLE
Fix Shift-Click Mechanics for Big filters, Up- and Downgrades (Fixes #11)

### DIFF
--- a/src/conduits/java/com/enderio/conduits/common/menu/ConduitMenu.java
+++ b/src/conduits/java/com/enderio/conduits/common/menu/ConduitMenu.java
@@ -57,6 +57,89 @@ public class ConduitMenu extends SyncedMenu<ConduitBlockEntity> {
         addInventorySlots(23,113);
     }
 
+    // EnderIO Unofficial: Override parent method
+    @Override
+    protected boolean moveItemStackTo(ItemStack stack, int startIndex, int endIndex, boolean reverseDirection) {
+        boolean flag = false;
+        int i = reverseDirection ? endIndex - 1 : startIndex;
+        Slot slot1;
+        ItemStack itemstack;
+        if (stack.isStackable()) {
+            while(!stack.isEmpty()) {
+                if (reverseDirection) {
+                    if (i < startIndex) break;
+                } else if (i >= endIndex) break;
+
+                slot1 = this.slots.get(i);
+                itemstack = slot1.getItem();
+                if (!itemstack.isEmpty() && ItemStack.isSameItemSameTags(stack, itemstack)) {
+                    int j = itemstack.getCount() + stack.getCount();
+                    // EnderIO Unofficial: Allow Stack-dependent maxStackSize in ConduitSlots
+                    int maxSize = Math.min(slot1 instanceof ConduitSlot cs ? cs.getMaxStackSizeItemAware(stack) : slot1.getMaxStackSize(), stack.getMaxStackSize());
+                    if (j <= maxSize) {
+                        stack.setCount(0);
+                        itemstack.setCount(j);
+                        slot1.setChanged();
+                        flag = true;
+                    } else if (itemstack.getCount() < maxSize) {
+                        stack.shrink(maxSize - itemstack.getCount());
+                        itemstack.setCount(maxSize);
+                        slot1.setChanged();
+                        flag = true;
+                    }
+                }
+
+                if (reverseDirection) {
+                    --i;
+                } else {
+                    ++i;
+                }
+            }
+        }
+
+        if (!stack.isEmpty()) {
+            if (reverseDirection) {
+                i = endIndex - 1;
+            } else {
+                i = startIndex;
+            }
+
+            while(true) {
+                if (reverseDirection) {
+                    if (i < startIndex) {
+                        break;
+                    }
+                } else if (i >= endIndex) {
+                    break;
+                }
+
+                slot1 = this.slots.get(i);
+                itemstack = slot1.getItem();
+                if (itemstack.isEmpty() && slot1.mayPlace(stack)) {
+                    // EnderIO Unofficial: Allow Stack-dependent maxStackSize in ConduitSlots
+                    int slotMaxStackSize = slot1 instanceof ConduitSlot cs ? cs.getMaxStackSizeItemAware(stack) : slot1.getMaxStackSize();
+                    if (stack.getCount() > slotMaxStackSize) {
+                        slot1.setByPlayer(stack.split(slotMaxStackSize));
+                    } else {
+                        slot1.setByPlayer(stack.split(stack.getCount()));
+                    }
+
+                    slot1.setChanged();
+                    flag = true;
+                    break;
+                }
+
+                if (reverseDirection) {
+                    --i;
+                } else {
+                    ++i;
+                }
+            }
+        }
+
+        return flag;
+    }
+
     @Override
     public ItemStack quickMoveStack(Player pPlayer, int pIndex) {
         ItemStack itemstack = ItemStack.EMPTY;

--- a/src/conduits/java/com/enderio/conduits/common/menu/ConduitSlot.java
+++ b/src/conduits/java/com/enderio/conduits/common/menu/ConduitSlot.java
@@ -40,14 +40,15 @@ public class ConduitSlot extends SlotItemHandler {
         return super.setBackground(atlas, sprite);
     }
 
+    //EnderIO Unofficial: Called from ConduitMenu to provide accurate Shift-Click mechanics
+    public int getMaxStackSizeItemAware(ItemStack stack) {
+        if(slotType != SlotType.UPGRADE_EXTRACT) return 1;
+        return stack.is(ConduitItems.SPEED_UPGRADE.asItem()) ? 15 : stack.is(ConduitItems.SPEED_DOWNGRADE.asItem()) ? 3 : 64;
+    }
+
     @Override
     public boolean mayPlace(ItemStack stack) {
-        // TODO check slot type, fluid filter for fluid etc...
-        return isVisible() && super.mayPlace(stack) && (
-            stack.is(ConduitItems.BASIC_ITEM_FILTER.asItem()))
-            || stack.is(ConduitItems.BIG_ITEM_FILTER.asItem())
-            || stack.is(ConduitItems.SPEED_UPGRADE.asItem())
-            || stack.is(ConduitItems.SPEED_DOWNGRADE.asItem());
+      return isVisible() && super.mayPlace(stack) && slotType.acceptsItem(stack.getItem());
     }
 
     @Override


### PR DESCRIPTION
# Description

Provide additional Validation logic to fix items vanishing when being inserted via shift click. Also allows for Item-dependent maximum stack sizes in `ConduitSlot`s to be respected when inserting via shift-click

Closes #11

# Checklist:

- [x] My code follows the style guidelines of this project (.editorconfig, most IDEs will use this for you).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in areas it may be challenging to understand. <!-- (Although we prefer code that is readable instead of over-commented) -->
- [x] I have made corresponding changes to the documentation.
- [x] My changes are ready for review from a contributor.